### PR TITLE
Arreglo de manejo de fechas y horas: guardado en UTC y conversión a zona horaria local (Argentina)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
-    "luxon": "^3.5.0",
     "reflect-metadata": "^0.2.2",
     "tsyringe": "^4.8.0",
     "zod": "^3.24.1"

--- a/src/application/dtos/envio/getEnvio.dto.ts
+++ b/src/application/dtos/envio/getEnvio.dto.ts
@@ -18,8 +18,21 @@ export class GetEnvioDto {
   ) {}
 
   public static create(envio: Envio): GetEnvioDto {
-    const fecha = envio.getFecha().toISOString().split('T')[0]; // 'YYYY-MM-DD'
-    const hora = envio.getHora().toISOString().split('T')[1].slice(0, 5); // 'HH:mm'
+    /**
+     * Se crea una nueva fecha con la fecha y hora del envío, para que pueda
+     * detectar el cambio de día. Si no siempre venia con horario
+     * en 00:00:00:000, y no se podía detectar si el utc era del día anterior o del actual.
+     */
+    const fechaHora = new Date(envio.getFecha().getTime() + envio.getHora().getTime());
+    const fecha = fechaHora.toLocaleDateString(
+      'es-AR',
+      { timeZone: 'America/Argentina/Buenos_Aires', year: 'numeric', month: '2-digit', day: '2-digit' }
+    );
+
+    const hora = envio.getHora().toLocaleTimeString(
+      'es-AR',
+      { timeZone: 'America/Argentina/Buenos_Aires', hour12: false }
+    ).slice(0, 5);
 
     return new GetEnvioDto(
       envio.getNroSeguimiento(),

--- a/src/application/dtos/envio/postEnvio.dto.ts
+++ b/src/application/dtos/envio/postEnvio.dto.ts
@@ -4,7 +4,7 @@ import { postEnvioValidation } from '../../validations/envio/postEnvio.validatio
 export class PostEnvioDto {
   private constructor(
     public descripcion: string,
-    public hora: string,
+    public hora: Date,
     public pesoGramos: number,
     public reserva: boolean,
     public origen: PostDomicilioDto,
@@ -19,9 +19,15 @@ export class PostEnvioDto {
       return [JSON.parse(envioValidation.error.message)];
     }
 
+    // Convierte la hora en formato Date para poder guardarla en la base de datos
+    const horaDate = new Date();
+    horaDate.setHours(Number(envioValidation.data.hora.split(':')[0]));
+    horaDate.setMinutes(Number(envioValidation.data.hora.split(':')[1]));
+    horaDate.setSeconds(0, 0);
+
     return [undefined, new PostEnvioDto(
       envioValidation.data.descripcion,
-      envioValidation.data.hora,
+      horaDate,
       envioValidation.data.pesoGramos,
       envioValidation.data.reserva,
       envioValidation.data.origen,

--- a/src/application/dtos/envio/postEnvio.dto.ts
+++ b/src/application/dtos/envio/postEnvio.dto.ts
@@ -4,7 +4,7 @@ import { postEnvioValidation } from '../../validations/envio/postEnvio.validatio
 export class PostEnvioDto {
   private constructor(
     public descripcion: string,
-    public hora: Date,
+    public hora: string,
     public pesoGramos: number,
     public reserva: boolean,
     public origen: PostDomicilioDto,
@@ -19,12 +19,9 @@ export class PostEnvioDto {
       return [JSON.parse(envioValidation.error.message)];
     }
 
-    // Convierte la hora en formato Date para poder guardarla en la base de datos
-    const hora = new Date(`1970-01-01T${envioValidation.data.hora}Z`); // La z es para que tome la hora en UTC
-
     return [undefined, new PostEnvioDto(
       envioValidation.data.descripcion,
-      hora,
+      envioValidation.data.hora,
       envioValidation.data.pesoGramos,
       envioValidation.data.reserva,
       envioValidation.data.origen,

--- a/src/application/dtos/envio/udpateEnvio.dto.ts
+++ b/src/application/dtos/envio/udpateEnvio.dto.ts
@@ -4,8 +4,7 @@ import { type UpdateDomicilioDto } from '../domicilio/updateDomicilio.dto';
 export class UpdateEnvioDto {
   private constructor(
     public descripcion: string,
-    public fecha: string,
-    public hora: string,
+    public hora: Date,
     public pesoGramos: number,
     public origen: UpdateDomicilioDto,
     public destino: UpdateDomicilioDto
@@ -18,10 +17,15 @@ export class UpdateEnvioDto {
       return [JSON.parse(envioValidation.error.message)];
     }
 
+    // Convierte la hora en formato Date para poder guardarla en la base de datos
+    const horaDate = new Date();
+    horaDate.setHours(Number(envioValidation.data.hora.split(':')[0]));
+    horaDate.setMinutes(Number(envioValidation.data.hora.split(':')[1]));
+    horaDate.setSeconds(0, 0);
+
     return [undefined, new UpdateEnvioDto(
       envioValidation.data.descripcion,
-      envioValidation.data.fecha,
-      envioValidation.data.hora,
+      horaDate,
       envioValidation.data.pesoGramos,
       envioValidation.data.origen,
       envioValidation.data.destino

--- a/src/application/dtos/envio/udpateEnvio.dto.ts
+++ b/src/application/dtos/envio/udpateEnvio.dto.ts
@@ -4,8 +4,8 @@ import { type UpdateDomicilioDto } from '../domicilio/updateDomicilio.dto';
 export class UpdateEnvioDto {
   private constructor(
     public descripcion: string,
-    public fecha: Date,
-    public hora: Date,
+    public fecha: string,
+    public hora: string,
     public pesoGramos: number,
     public origen: UpdateDomicilioDto,
     public destino: UpdateDomicilioDto
@@ -18,13 +18,10 @@ export class UpdateEnvioDto {
       return [JSON.parse(envioValidation.error.message)];
     }
 
-    const fecha = new Date(envioValidation.data.fecha);
-    const hora = new Date(`1970-01-01T${envioValidation.data.hora}Z`);
-
     return [undefined, new UpdateEnvioDto(
       envioValidation.data.descripcion,
-      fecha,
-      hora,
+      envioValidation.data.fecha,
+      envioValidation.data.hora,
       envioValidation.data.pesoGramos,
       envioValidation.data.origen,
       envioValidation.data.destino

--- a/src/application/dtos/viaje/getAllByConductorId.dto.ts
+++ b/src/application/dtos/viaje/getAllByConductorId.dto.ts
@@ -10,15 +10,12 @@ export class GetAllByConductorIdDto {
   ) {}
 
   public static create(viaje: Viaje): GetAllByConductorIdDto {
-    const fechaFin = viaje.getFechaFin()?.toISOString().split('T')[0];
-    const fechaInicio = viaje.getFechaInicio()?.toISOString().split('T')[0];
-
     return new GetAllByConductorIdDto(
       viaje.getIdViaje(),
       viaje.getIdConductor(),
       viaje.getEnvio().getNroSeguimiento(),
-      fechaFin,
-      fechaInicio
+      viaje.getFechaFin(),
+      viaje.getFechaInicio()
     );
   }
 }

--- a/src/application/dtos/viaje/getAllByConductorId.dto.ts
+++ b/src/application/dtos/viaje/getAllByConductorId.dto.ts
@@ -10,12 +10,15 @@ export class GetAllByConductorIdDto {
   ) {}
 
   public static create(viaje: Viaje): GetAllByConductorIdDto {
+    const fechaFin = viaje.getFechaFin()?.toISOString().split('T')[0];
+    const fechaInicio = viaje.getFechaInicio()?.toISOString().split('T')[0];
+
     return new GetAllByConductorIdDto(
       viaje.getIdViaje(),
       viaje.getIdConductor(),
       viaje.getEnvio().getNroSeguimiento(),
-      viaje.getFechaFin(),
-      viaje.getFechaInicio()
+      fechaFin,
+      fechaInicio
     );
   }
 }

--- a/src/application/dtos/viaje/getViaje.dto.ts
+++ b/src/application/dtos/viaje/getViaje.dto.ts
@@ -4,26 +4,23 @@ import { type Viaje } from '../../../domain/entities/viaje.entity';
 export class GetViajeDto {
   private constructor(
     public checkpointActual: number,
-    public fechaFin: string,
-    public fechaInicio: string,
     public idConductor: string,
     public nroSeguimiento: number,
     public origenCord: Coordenada,
-    public destinoCord: Coordenada
+    public destinoCord: Coordenada,
+    public fechaInicio?: string | null,
+    public fechaFin?: string | null
   ) {}
 
   public static create(viaje: Viaje): GetViajeDto {
-    const fechaFin = viaje.getFechaFin()?.toISOString().split('T')[0] || '';
-    const fechaInicio = viaje.getFechaInicio()?.toISOString().split('T')[0] || '';
-
     return new GetViajeDto(
       viaje.getCheckpointActual(),
-      fechaFin,
-      fechaInicio,
       viaje.getIdConductor(),
       viaje.getEnvio().getNroSeguimiento(),
       viaje.getOrigenCord(),
-      viaje.getDestinoCord()
+      viaje.getDestinoCord(),
+      viaje.getFechaInicio(),
+      viaje.getFechaFin()
     );
   }
 }

--- a/src/application/dtos/viaje/getViaje.dto.ts
+++ b/src/application/dtos/viaje/getViaje.dto.ts
@@ -4,24 +4,26 @@ import { type Viaje } from '../../../domain/entities/viaje.entity';
 export class GetViajeDto {
   private constructor(
     public checkpointActual: number,
+    public fechaFin: string,
+    public fechaInicio: string,
     public idConductor: string,
     public nroSeguimiento: number,
     public origenCord: Coordenada,
-    public destinoCord: Coordenada,
-    public fechaInicio?: string | null,
-    public fechaFin?: string | null
+    public destinoCord: Coordenada
   ) {}
 
   public static create(viaje: Viaje): GetViajeDto {
+    const fechaFin = viaje.getFechaFin()?.toISOString().split('T')[0] || '';
+    const fechaInicio = viaje.getFechaInicio()?.toISOString().split('T')[0] || '';
+
     return new GetViajeDto(
       viaje.getCheckpointActual(),
+      fechaFin,
+      fechaInicio,
       viaje.getIdConductor(),
       viaje.getEnvio().getNroSeguimiento(),
       viaje.getOrigenCord(),
-      viaje.getDestinoCord(),
-      viaje.getFechaInicio(),
-      viaje.getFechaFin()
+      viaje.getDestinoCord()
     );
   }
 }
-

--- a/src/application/mappers/envio.mapper.ts
+++ b/src/application/mappers/envio.mapper.ts
@@ -66,7 +66,7 @@ export class EnvioMapper {
     return new Envio(
       existingEnvio.getNroSeguimiento(),
       updateEnvioDto.descripcion,
-      updateEnvioDto.fecha,
+      existingEnvio.getFecha(),
       updateEnvioDto.hora,
       updateEnvioDto.pesoGramos,
       existingEnvio.calcularMonto(),

--- a/src/application/services/envios.service.ts
+++ b/src/application/services/envios.service.ts
@@ -130,7 +130,7 @@ export class EnviosService {
       envioToUpdate.setMonto(envioToUpdate.calcularMonto());
     }
 
-    if (updateEnvioDto.hora !== existingEnvio.getHora()) {
+    if (updateEnvioDto.hora.getHours() !== existingEnvio.getHora().getHours()) {
       envioToUpdate.verificarRangoHorario();
     }
 

--- a/src/application/services/envios.service.ts
+++ b/src/application/services/envios.service.ts
@@ -13,6 +13,7 @@ import { Inject, Injectable } from '../../infrastructure/dependencies/injectable
 import { REPOSITORIES_TOKENS } from '../../infrastructure/dependencies/repositories-tokens.dependency';
 import { type Domicilio } from '../../domain/entities/domicilio.entity';
 import { DomicilioMapper } from '../mappers/domicilio.mapper';
+import { ViajesService } from './viajes.service';
 
 @Injectable()
 export class EnviosService {
@@ -20,7 +21,8 @@ export class EnviosService {
     @Inject(REPOSITORIES_TOKENS.IEnviosRepository) private readonly enviosRepository: IEnviosRepository,
     @Inject(REPOSITORIES_TOKENS.IDomiciliosRepository) private readonly domicilioRepository: IDomicilioRepository,
     @Inject(REPOSITORIES_TOKENS.ILocalidadesRepository) private readonly localidadRepository: ILocalidadRepository,
-    @Inject(REPOSITORIES_TOKENS.IUsuariosRepository) private readonly clienteRepository: IUsuarioRepository
+    @Inject(REPOSITORIES_TOKENS.IUsuariosRepository) private readonly clienteRepository: IUsuarioRepository,
+    private readonly viajeService: ViajesService
   ) {}
 
   public async getAll(): Promise<Envio[]> {
@@ -77,7 +79,8 @@ export class EnviosService {
     if (!envio.verificarRangoHorario()) throw CustomError.badRequest(`El horario de entrega debe ser entre las ${HORA_INICIO} y ${HORA_FIN} horas`);
 
     envio.verificarReserva();
-    // TODO: Implementar crear viaje() para el envio
+
+    // TODO: Implementar buscar conductor disponible
 
     // Setea los domicilios con sus IDs si existen, sino los crea
     envio.setOrigen(await this.getOrCreateDomicilio(envio.getOrigen()));
@@ -89,6 +92,9 @@ export class EnviosService {
     }
 
     const nroSeguimiento = await this.enviosRepository.create(envio);
+
+    await this.viajeService.create(envio, '789a1234-e21c-98d3-b123-426614174003');
+
     return nroSeguimiento;
   }
 
@@ -124,7 +130,7 @@ export class EnviosService {
       envioToUpdate.setMonto(envioToUpdate.calcularMonto());
     }
 
-    if (updateEnvioDto.hora.getHours() !== existingEnvio.getHora().getHours()) {
+    if (updateEnvioDto.hora !== existingEnvio.getHora()) {
       envioToUpdate.verificarRangoHorario();
     }
 

--- a/src/application/services/viajes.service.ts
+++ b/src/application/services/viajes.service.ts
@@ -31,7 +31,7 @@ export class ViajesService {
   }
 
   // crea un viaje
-  public async create(envio: Envio): Promise<number> {
+  public async create(envio: Envio, idConductor: string): Promise<number> {
     const origenData = await obtenerCoordOrigen(envio);
     const destinoData = await obtenerCoordDestino(envio);
 
@@ -53,18 +53,12 @@ export class ViajesService {
     origen.setIdCoordenada(origenId);
     destino.setIdCoordenada(destinoId);
 
-    // gardo fecha y hora en una sola variable
-    const fechaHoraInicio = `${envio.getFecha().getDay()} ${envio.getHora().getTime()}`;
-    const fechaHoraInicioDate = new Date(fechaHoraInicio);
-
-    // llamar a la funcion de buscar un conductor disponible
-
     const newViaje = new Viaje(
       0,
       1,
-      fechaHoraInicioDate,
+      envio.getHora(), // Despues lo cambio
       null,
-      '0', // Buscar conductor disponible
+      idConductor,
       envio,
       origen,
       destino

--- a/src/application/services/viajes.service.ts
+++ b/src/application/services/viajes.service.ts
@@ -53,10 +53,18 @@ export class ViajesService {
     origen.setIdCoordenada(origenId);
     destino.setIdCoordenada(destinoId);
 
+    // Crear un nuevo objeto Date con la fecha y la hora combinada
+    const fecha = envio.getFecha();
+    const hora = envio.getHora();
+    const fechaHora = new Date(fecha);
+    fechaHora.setHours(Number(hora.getHours()));
+    fechaHora.setMinutes(Number(hora.getMinutes()));
+    fechaHora.setSeconds(0, 0);
+
     const newViaje = new Viaje(
       0,
       1,
-      envio.getHora(), // Despues lo cambio
+      fechaHora, // Despues lo cambio
       null,
       idConductor,
       envio,

--- a/src/application/validations/envio/udpateEnvio.validation.ts
+++ b/src/application/validations/envio/udpateEnvio.validation.ts
@@ -4,7 +4,6 @@ import { UpdateDomicilioSchema } from '../domicilio/updateEnvio.validation';
 
 export const UpdateEnvioSchema = z.object({
   descripcion: z.string(),
-  fecha: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Fecha en formato YYYY-MM-DD'),
   hora: z.string().regex(/^\d{2}:\d{2}$/, 'Hora en formato HH:mm'),
   pesoGramos: z.number().int().positive(),
   reserva: z.boolean(),

--- a/src/domain/entities/envio.entity.ts
+++ b/src/domain/entities/envio.entity.ts
@@ -7,14 +7,16 @@ export const PESO_GRAMOS_MAX = 20000;
 const PRECIO_CADA_100_GRAMOS = 500;
 export const HORA_INICIO = 8;
 export const HORA_FIN = 18;
-const DIFERENCIA_HORARIA = 3;
+
+const fechaHoraActualTipoDate = new Date();
+const fechaHoraActual = fechaHoraActualTipoDate.toLocaleString('es-AR', { timeZone: 'America/Argentina/Buenos_Aires', hour12: false });
 
 export class Envio {
   constructor(
     private nroSeguimiento: number,
     private descripcion: string,
-    private fecha: Date = new Date(),
-    private hora: Date,
+    private fecha: string = fechaHoraActual.split(',')[0].trim(),
+    private hora: string,
     private pesoGramos: number,
     private monto: number = this.calcularMonto(),
     private reserva: boolean = false,
@@ -33,11 +35,11 @@ export class Envio {
     return this.descripcion;
   }
 
-  public getFecha(): Date {
+  public getFecha(): string {
     return this.fecha;
   }
 
-  public getHora(): Date {
+  public getHora(): string {
     return this.hora;
   }
 
@@ -78,11 +80,11 @@ export class Envio {
     this.descripcion = descripcion;
   }
 
-  public setFecha(fecha: Date): void {
+  public setFecha(fecha: string): void {
     this.fecha = fecha;
   }
 
-  public setHora(hora: Date): void {
+  public setHora(hora: string): void {
     this.hora = hora;
   }
 
@@ -121,22 +123,31 @@ export class Envio {
 
   // Verificacion del rango horario que viene en el json
   public verificarRangoHorario(): boolean {
-    if (this.hora.getUTCHours() < HORA_INICIO || this.hora.getUTCHours() > HORA_FIN) {
+    const hora = Number(this.hora.split(':')[0]); // HH:mm
+    if (hora < HORA_INICIO || hora > HORA_FIN) {
       return false;
     }
     return true;
   }
 
   /* Si se manda un rango horario valido se verifica que:
-    1) Si el envio no es reserva, la fecha y hora de la reserva es la actual (fecha actual por defecto, hora actual pasada por json)
+    1) Si el envio no es reserva, la fecha y hora de la reserva es la actual (fecha actual por defecto)
     2) Si el envio es reserva, se verifica la fecha:
       - Si la hora actual esta fuera del rango horario, la reserva es para el dia siguiente
       - Si la hora actual esta dentro del rango horario, la reserva es para el mismo dia (fecha actual por defecto)
   */
   public verificarReserva(): void {
-    const horaActual = this.fecha.getUTCHours() - DIFERENCIA_HORARIA;
+    if (!this.reserva) {
+      this.hora = fechaHoraActual.split(',')[1].trim();
+      return;
+    }
+    const horaActual = Number(fechaHoraActual.split(',')[1].trim().split(':')[0]); // hh:mm:ss
+    console.log(horaActual);
     if (horaActual < HORA_INICIO || horaActual > HORA_FIN) {
-      this.fecha.setDate(this.fecha.getDate() + 1);
+      const nextDay = new Date(fechaHoraActualTipoDate);
+      nextDay.setDate(fechaHoraActualTipoDate.getDate() + 1);
+      const nextDayToString = nextDay.toLocaleString('es-AR', { timeZone: 'America/Argentina/Buenos_Aires', hour12: false }).split(',')[0].trim();
+      this.fecha = nextDayToString;
     }
   }
 

--- a/src/domain/entities/viaje.entity.ts
+++ b/src/domain/entities/viaje.entity.ts
@@ -5,8 +5,8 @@ export class Viaje {
   constructor(
     private readonly idViaje: number,
     private checkpointActual: number,
-    private fechaInicio: Date | null,
-    private fechaFin: Date | null,
+    private fechaInicio: string | null,
+    private fechaFin: string | null,
     private idConductor: string,
     private envio: Envio,
     private origenCord: Coordenada,
@@ -22,11 +22,11 @@ export class Viaje {
     return this.checkpointActual;
   }
 
-  public getFechaInicio(): Date | null {
+  public getFechaInicio(): string | null {
     return this.fechaInicio;
   }
 
-  public getFechaFin(): Date | null {
+  public getFechaFin(): string | null {
     return this.fechaFin;
   }
 
@@ -52,11 +52,11 @@ export class Viaje {
     this.checkpointActual = checkpointActual;
   }
 
-  public setFechaInicio(fechaInicio: Date): void {
+  public setFechaInicio(fechaInicio: string): void {
     this.fechaInicio = fechaInicio;
   }
 
-  public setFechaFin(fechaFin: Date): void {
+  public setFechaFin(fechaFin: string): void {
     this.fechaFin = fechaFin;
   }
 

--- a/src/domain/entities/viaje.entity.ts
+++ b/src/domain/entities/viaje.entity.ts
@@ -5,8 +5,8 @@ export class Viaje {
   constructor(
     private readonly idViaje: number,
     private checkpointActual: number,
-    private fechaInicio: string | null,
-    private fechaFin: string | null,
+    private fechaInicio: Date | null,
+    private fechaFin: Date | null,
     private idConductor: string,
     private envio: Envio,
     private origenCord: Coordenada,
@@ -22,11 +22,11 @@ export class Viaje {
     return this.checkpointActual;
   }
 
-  public getFechaInicio(): string | null {
+  public getFechaInicio(): Date | null {
     return this.fechaInicio;
   }
 
-  public getFechaFin(): string | null {
+  public getFechaFin(): Date | null {
     return this.fechaFin;
   }
 
@@ -52,11 +52,11 @@ export class Viaje {
     this.checkpointActual = checkpointActual;
   }
 
-  public setFechaInicio(fechaInicio: string): void {
+  public setFechaInicio(fechaInicio: Date): void {
     this.fechaInicio = fechaInicio;
   }
 
-  public setFechaFin(fechaFin: string): void {
+  public setFechaFin(fechaFin: Date): void {
     this.fechaFin = fechaFin;
   }
 

--- a/src/infrastructure/repositories/envios.repository.ts
+++ b/src/infrastructure/repositories/envios.repository.ts
@@ -110,6 +110,8 @@ export class EnviosRepository implements IEnviosRepository {
     return EnvioPrismaMapper.fromPrismaToEntity(envioPrisma);
   }
 
+
+  // La bd guarda la fecha y hora en UTC
   public async create(envio: Envio): Promise<number> {
     const envioData = await this.prisma.envios.create({
       data: {

--- a/src/utils/getArgentinaDate.ts
+++ b/src/utils/getArgentinaDate.ts
@@ -1,0 +1,13 @@
+function getArgentinaDate() {
+  const now = new Date();
+
+  const offset = -3 * 60; // Argentina está en UTC-3
+
+  const argentinaDate = new Date(now.getTime() + (offset - now.getTimezoneOffset()) * 60000);
+
+  return argentinaDate;
+}
+
+// Ejemplo de uso
+const argentinaNow = getArgentinaDate();
+console.log('Fecha y hora en Argentina:', argentinaNow.toLocaleString('es-AR'));


### PR DESCRIPTION
El problema original radicaba en cómo se almacenaban las fechas y horas que se pasaban desde el front-end y cómo se devolvían desde el back-end, por lo que no se podían hacer cálculos coherentes. 

>[!Note]
>JavaScript trabaja internamente el new Date() siempre en UTC. El UTC es el estándar de tiempo universal que no depende de ninguna zona horaria. Cada país o región aplica una diferencia horaria respecto al UTC, representada con un desplazamiento positivo (+) o negativo (-), dependiendo de su ubicación geográfica, por ejemplo, Argentina está en UTC-3. Esto significa que por ejemplo si son las 15:00 en ARG, en UTC serían las 18:00.

Para solucionarlo, implementé lo siguiente:

- Guardado en UTC: Las fechas y horas se almacenan en la base de datos en formato UTC.
- Conversión a zona horaria local: Al devolver las fechas y horas al front-end, se formatean según la zona horaria de Argentina para ser correctamente mostradas en la UI.
- Manejo combinado de fecha y hora: Para los viajes, combiné los campos de fecha y hora, lo que permite trabajar con un solo objeto y además obtenemos los datos actuales de ambos campos.

Con estos cambios, se facilita la gestión de fechas y horas en la aplicación y se resuelven problemas de cálculos y presentación de fechas.